### PR TITLE
Support year abbreviations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const evilApostropheRegExp = /\w+['‘](?:\w['‘])?\w*/g;
+const evilApostropheRegExp = /(?:(?<=\s)|[^\d\W])+['‘](?:\w['‘])?\w*/g;
 const evilApostrophe = /['‘]/g;
 const goodApostrophe = '’';
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const TextLintTester = require('textlint-tester');
+const TextLintTester = require('textlint-tester').default;
 const rule = require('./index');
 
 const tester = new TextLintTester();
@@ -8,6 +8,9 @@ tester.run('apostrophe', rule, {
 		'I’m looking forward',
 		'rock’n’roll',
 		'my sisters’ friends’ investments',
+		'Summer of ’69',
+		'Personal best: 00\'03"48',
+		'Latitude: 49° 53\' 08"',
 	],
 	invalid: [
 		{
@@ -41,6 +44,24 @@ tester.run('apostrophe', rule, {
 				{
 					message:
 						"Incorrect usage of an apostrophe: “friends'”, use “friends’” instead",
+				},
+			],
+		},
+		{
+			text: "Summer of '69",
+			output: 'Summer of ’69',
+			errors: [
+				{
+					message: "Incorrect usage of an apostrophe: “'69”, use “’69” instead",
+				},
+			],
+		},
+		{
+			text: 'Summer of ‘69',
+			output: 'Summer of ’69',
+			errors: [
+				{
+					message: 'Incorrect usage of an apostrophe: “‘69”, use “’69” instead',
 				},
 			],
 		},


### PR DESCRIPTION
Support using the correct apostrophe style (`’`) for two-digit year abbreviations (e.g. `Summer of ’69`)

Ensures that other similar situations involving numbers and apostrophes do not get inadvertently changed.

Fixes #13 